### PR TITLE
Update loopsubtask.yml

### DIFF
--- a/Chapter 4/loopsubtask.yml
+++ b/Chapter 4/loopsubtask.yml
@@ -6,3 +6,5 @@
     - 100
     - 200
     - 300
+  loop_control:
+    loop_var: first_item


### PR DESCRIPTION
Also have to add loop control in subtask as its failing with error "fatal: [gurmeetsingh3c.mylabserver.com]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'first_item' is undefined\n\nThe error appears to be in '/home/cloud_user/loopsubtask.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Inner Loop\n  ^ here\n"}". if not added